### PR TITLE
Change ERROR_OUTPUT of secureEndpoint

### DIFF
--- a/src/main/scala/auth/JwtAuthenticator.scala
+++ b/src/main/scala/auth/JwtAuthenticator.scala
@@ -36,12 +36,10 @@ case class JwtAuthenticator[T] (
   def flatMapJwtF[R](f: T => IO[Either[String, R]]): JwtAuthenticator[R] =
     copy(jwtProcessor = jwtProcessor.andThen(e => EitherT(e).flatMap(t => EitherT(f(t))).value))
 
-  def secureEndpoint: PartialServerEndpoint[Option[String], T, Unit, Exception, Unit, Any, IO] =
+  def secureEndpoint: PartialServerEndpoint[Option[String], T, Unit, AuthException, Unit, Any, IO] =
     baseEndpoint
       .securityIn(header[Option[String]]("Authorization"))
-      .errorOut(oneOf[Exception](
-        oneOfVariant(StatusCode.Unauthorized, jsonBody[String].mapTo[AuthException])
-      ))
+      .errorOut(statusCode(StatusCode.Unauthorized).and(jsonBody[String].mapTo[AuthException]))
       .serverSecurityLogic(authenticateHeader(_).map(_.left.map(AuthException(_))))
 
   def authenticateHeader(headerOption: Option[String]): IO[Either[String, T]] =


### PR DESCRIPTION
Setting the first error output to `Exception` will ignore subsequent error variants in runtime.
```scala
endpoint
.errorOut(
  oneOf[Exception](
    oneOfVariant(StatusCode.Unauthorized, jsonBody[String].mapTo[AuthException])
  )
) // Endpoint[Unit, Unit, Exception, Unit, Any]
.errorOutVariant(oneOfVariant(statusCode(StatusCode.NotFound).and(stringBody.mapTo[NotFoundException])))
.serverLogic(_ => IO(Left(NotFoundException("")))) // returns 500
```

If it's `AuthException`, other variants are checked. (removed `oneOf` since `errorOutVariant` wraps the error into `oneOf`).
```scala
endpoint
.errorOut(statusCode(StatusCode.Unauthorized).and(jsonBody[String].mapTo[AuthException])) ) // Endpoint[Unit, Unit, AuthException, Unit, Any]
.errorOutVariant(oneOfVariant(statusCode(StatusCode.NotFound).and(stringBody.mapTo[NotFoundException])))
.serverLogic(_ => IO(Left(NotFoundException("")))) // returns 404
```