### PR TITLE
Authenticator trait

### DIFF
--- a/src/main/scala/auth/Authenticator.scala
+++ b/src/main/scala/auth/Authenticator.scala
@@ -1,0 +1,50 @@
+package io.blindnet.identityclient
+package auth
+
+import cats.data.EitherT
+import cats.effect.{IO, *}
+import io.blindnet.jwt.{Token, TokenPublicKey}
+import sttp.model.StatusCode
+import sttp.tapir.*
+import sttp.tapir.json.circe.*
+import sttp.tapir.server.*
+
+import java.util.UUID
+import scala.util.Try
+
+trait Authenticator[T] {
+
+  def or(other: Authenticator[T]): Authenticator[T] = {
+    val that = this
+
+    new Authenticator[T] {
+      def authenticateToken(raw: String): IO[Either[String, T]] =
+        other.authenticateToken(raw).flatMap {
+          case Right(t) => IO(Right(t))
+          case Left(e) => that.authenticateToken(raw)
+        }
+    }
+  }
+
+  def secureEndpoint(baseEndpoint: PublicEndpoint[Unit, Unit, Unit, Any]): PartialServerEndpoint[Option[String], T, Unit, AuthException, Unit, Any, IO] =
+    baseEndpoint
+      .securityIn(header[Option[String]]("Authorization"))
+      .errorOut(statusCode(StatusCode.Unauthorized).and(jsonBody[String].mapTo[AuthException]))
+      .serverSecurityLogic(authenticateHeader(_).map(_.left.map(AuthException(_))))
+
+  def authenticateHeader(headerOption: Option[String]): IO[Either[String, T]] =
+    headerOption match
+      case Some(header) =>
+        EitherT.fromEither[IO](extractTokenFromHeader(header))
+          .flatMap(token => EitherT(authenticateToken(token)))
+          .value
+      case None => IO.pure(Left("Missing Authorization header"))
+    
+  def extractTokenFromHeader(header: String): Either[String, String] =
+    header match {
+      case s"Bearer $token" => Right(token)
+      case _              => Left("Invalid Authorization header")
+    }
+
+  def authenticateToken(raw: String): IO[Either[String, T]]
+}

--- a/src/main/scala/auth/ConstAuthenticator.scala
+++ b/src/main/scala/auth/ConstAuthenticator.scala
@@ -15,35 +15,9 @@ import scala.util.Try
 case class ConstAuthenticator[T] (
   token: String,
   value: IO[T],
-  private val baseEndpoint: PublicEndpoint[Unit, Unit, Unit, Any] = endpoint,
-) {
-  def withBaseEndpoint(endpoint: PublicEndpoint[Unit, Unit, Unit, Any]): ConstAuthenticator[T] =
-    copy(baseEndpoint = endpoint)
-
-  def secureEndpoint: PartialServerEndpoint[Option[String], T, Unit, (StatusCode, String), Unit, Any, IO] =
-    baseEndpoint
-      .securityIn(header[Option[String]]("Authorization"))
-      .errorOut(statusCode)
-      .errorOut(jsonBody[String])
-      .serverSecurityLogic(authenticateHeader(_).map(_.left.map((StatusCode.Unauthorized, _))))
-
-  def authenticateHeader(headerOption: Option[String]): IO[Either[String, T]] =
-    headerOption match
-      case Some(header) => authenticateHeader(header)
-      case None => IO.pure(Left("Missing Authorization header"))
-
-  def authenticateHeader(header: String): IO[Either[String, T]] =
-    EitherT.fromEither[IO](extractTokenFromHeader(header))
-      .flatMap(token => EitherT(authenticateToken(token)))
-      .value
+) extends Authenticator[T] {
 
   def authenticateToken(raw: String): IO[Either[String, T]] =
     if raw == token then value.map(Right(_))
     else IO.pure(Left("Invalid token"))
-
-  private def extractTokenFromHeader(header: String): Either[String, String] =
-    header match {
-      case s"Bearer $token" => Right(token)
-      case _              => Left("Invalid Authorization header")
-    }
 }

--- a/src/main/scala/auth/JwtAuthenticator.scala
+++ b/src/main/scala/auth/JwtAuthenticator.scala
@@ -14,11 +14,8 @@ import scala.util.Try
 
 case class JwtAuthenticator[T] (
   identityClient: IdentityClient,
-  private val baseEndpoint: PublicEndpoint[Unit, Unit, Unit, Any] = endpoint,
   private val jwtProcessor: Jwt => IO[Either[String, T]] = jwt => IO.pure(Right(jwt)),
-) {
-  def withBaseEndpoint(endpoint: PublicEndpoint[Unit, Unit, Unit, Any]): JwtAuthenticator[T] =
-    copy(baseEndpoint = endpoint)
+) extends Authenticator[T] {
 
   def requireAppJwt: JwtAuthenticator[AppJwt] = require(_.asApp)
   def requireAnyUserJwt: JwtAuthenticator[AnyUserJwt] = require(_.asAnyUser)
@@ -36,22 +33,6 @@ case class JwtAuthenticator[T] (
   def flatMapJwtF[R](f: T => IO[Either[String, R]]): JwtAuthenticator[R] =
     copy(jwtProcessor = jwtProcessor.andThen(e => EitherT(e).flatMap(t => EitherT(f(t))).value))
 
-  def secureEndpoint: PartialServerEndpoint[Option[String], T, Unit, AuthException, Unit, Any, IO] =
-    baseEndpoint
-      .securityIn(header[Option[String]]("Authorization"))
-      .errorOut(statusCode(StatusCode.Unauthorized).and(jsonBody[String].mapTo[AuthException]))
-      .serverSecurityLogic(authenticateHeader(_).map(_.left.map(AuthException(_))))
-
-  def authenticateHeader(headerOption: Option[String]): IO[Either[String, T]] =
-    headerOption match
-      case Some(header) => authenticateHeader(header)
-      case None => IO.pure(Left("Missing Authorization header"))
-
-  def authenticateHeader(header: String): IO[Either[String, T]] =
-    EitherT.fromEither[IO](extractTokenFromHeader(header))
-      .flatMap(token => EitherT(authenticateToken(token)))
-      .value
-
   def authenticateToken(raw: String): IO[Either[String, T]] =
     (for {
       token <- EitherT.fromEither[IO](parseToken(raw))
@@ -60,12 +41,6 @@ case class JwtAuthenticator[T] (
       jwt <- EitherT.pure[IO, String](Jwt.fromJavaToken(token))
       mapped <- EitherT(jwtProcessor(jwt))
     } yield mapped).value
-
-  private def extractTokenFromHeader(header: String): Either[String, String] =
-    header match {
-      case s"Bearer $jwt" => Right(jwt)
-      case _              => Left("Invalid Authorization header")
-    }
 
   private def parseToken(raw: String): Either[String, Token] =
     Try(Token.parse(raw)).toEither.left.map(_.getMessage)


### PR DESCRIPTION
Adds the common trait for authenticators using the Authorization header in `Bearer token` format.
Not a generic solution since it can't handle other scenarios (like auth data in different headers) but saves some boilerplate for now.

`baseEndpoint` is now a parameter of `secureEndpoint` method, as it might not be needed.

example:
```
jwtAuthenticator.mapJwt(_.appId)
  .compose(stAuthenticator.mapSt(_.appId))
  .secureEndpoint(base)
```